### PR TITLE
Optional server cvar for setting default teamplay skins

### DIFF
--- a/source/g_local.h
+++ b/source/g_local.h
@@ -1109,8 +1109,12 @@ extern cvar_t *medkit_drop;
 extern cvar_t *medkit_time;
 extern cvar_t *medkit_instant;
 
-// AQ2 ETE
+extern cvar_t *teamplay_use_ctf_skins;
+
+// BEGIN AQ2 ETE
 extern cvar_t *e_enhancedSlippers;
+
+// END AQ2 ETE
 
 extern cvar_t *sv_limp_highping;
 

--- a/source/g_main.c
+++ b/source/g_main.c
@@ -465,8 +465,12 @@ cvar_t *medkit_instant;
 
 cvar_t *jump;			// jumping mod
 
-// AQ2 ETE Add
+cvar_t *teamplay_use_ctf_skins;
+
+
+// BEGIN AQ2 ETE
 cvar_t *e_enhancedSlippers;
+// END AQ2 ETE
 
 cvar_t *sv_limp_highping;
 

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -544,7 +544,11 @@ void InitGame( void )
 
 	use_mvd2 = gi.cvar( "use_mvd2", "0", 0 );	// JBravo: q2pro MVD2 recording. 0 = off, 1 = on
 
-	e_enhancedSlippers = gi.cvar( "e_enhancedSlippers", "0", 0); // darksaint: AQ2 ETE
+	teamplay_use_ctf_skins = gi.cvar( "teamplay_use_ctf_skins", "0", 0);
+
+	// BEGIN AQ2 ETE
+	e_enhancedSlippers = gi.cvar( "e_enhancedSlippers", "0", 0);
+	// END AQ2 ETE
 
 	sv_limp_highping = gi.cvar("sv_limp_highping", "70", CVAR_SERVERINFO);
 

--- a/source/g_spawn.c
+++ b/source/g_spawn.c
@@ -1043,6 +1043,15 @@ void SpawnEntities (char *mapname, char *entities, char *spawnpoint)
 	else if (teamplay->value)
 	{
 		gameSettings |= (GS_ROUNDBASED | GS_WEAPONCHOOSE);
+
+		if (teamplay_use_ctf_skins->value) {
+			strcpy(teams[TEAM1].name, "RED");
+			strcpy(teams[TEAM2].name, "BLUE");
+			strcpy(teams[TEAM1].skin, "male/ctf_r");
+			strcpy(teams[TEAM2].skin, "male/ctf_b");
+			strcpy(teams[TEAM1].skin_index, "i_ctf1");
+			strcpy(teams[TEAM2].skin_index, "i_ctf2");
+		}
 	}
 	else { //Its deathmatch
 		gameSettings |= GS_DEATHMATCH;


### PR DESCRIPTION
Set `teamplay_use_ctf_skins` to `1` to use the same skins as CTF (`male/ctf_r` and `male/ctf_b`) as well as the names `RED` and `BLUE`