### PR TITLE
MSVC 2019 compiler check for UUID, adjusted x64 base address, add silence code

### DIFF
--- a/source/a_cmds.c
+++ b/source/a_cmds.c
@@ -134,8 +134,10 @@
 #include "g_local.h"
 #include <time.h>
 #ifdef WIN32
+#if _MSC_VER >= 1920 && !__INTEL_COMPILER
 #pragma comment(lib, "rpcrt4.lib")
 #include <rpc.h>
+#endif
 #else
 #include <uuid/uuid.h>
 #endif
@@ -1226,37 +1228,39 @@ void Cmd_Ghost_f(edict_t * ent)
 
 void generate_uuid()
 {
-// #ifdef WIN32
-//     UUID uuid;
-//     unsigned char* uuidStr;
+#ifdef WIN32
+#if _MSC_VER >= 1920 && !__INTEL_COMPILER
+     UUID uuid;
+     unsigned char* uuidStr;
 
-//     if (UuidCreate(&uuid) != RPC_S_OK)
-//     {
-//         gi.dprintf("%s unable to create UUID\n", __func__);
-//         return;
-//     }
-//     if (UuidToStringA(&uuid, &uuidStr) != RPC_S_OK)
-//     {
-//         gi.dprintf("%s unable to format UUID as a string\n", __func__);
-//         return;
-//     }
+     if (UuidCreate(&uuid) != RPC_S_OK)
+     {
+         gi.dprintf("%s unable to create UUID\n", __func__);
+         return;
+     }
+     if (UuidToStringA(&uuid, &uuidStr) != RPC_S_OK)
+     {
+         gi.dprintf("%s unable to format UUID as a string\n", __func__);
+         return;
+     }
 
-//     strncpy(game.matchid, uuidStr, MAX_QPATH);
-//     //gi.dprintf("%s UUID: %s\n", __func__, game.matchid);
+     strncpy(game.matchid, uuidStr, MAX_QPATH);
+     //gi.dprintf("%s UUID: %s\n", __func__, game.matchid);
 
-//     if (RpcStringFreeA(&uuidStr) != RPC_S_OK)
-//     {
-//         gi.dprintf("Failed to free UUID display string\n", __func__);
-//         return;
-//     }
-// #else
+     if (RpcStringFreeA(&uuidStr) != RPC_S_OK)
+     {
+         gi.dprintf("Failed to free UUID display string\n", __func__);
+         return;
+     }
+#endif
+#else
     char uuidBuff[MAX_QPATH]; // Make the buffer slightly larger than required
     uuid_t uuidGenerated;
     uuid_generate_random(uuidGenerated); // The UUID is 16 bytes (128 bits) long, which gives approximately 3.4x10^38 unique values
     uuid_unparse(uuidGenerated, uuidBuff);
     strncpy(game.matchid, uuidBuff, MAX_QPATH);
     //gi.dprintf("%s UUID: %s\n", __func__, game.matchid);
-//#endif
+#endif
 }
 
 #ifndef NO_BOTS

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -1085,6 +1085,7 @@ extern cvar_t *dedicated;
 extern cvar_t *steamid;
 
 extern cvar_t *filterban;
+extern cvar_t* silenceban; //rekkie -- silence ban
 extern cvar_t *flood_threshold;
 
 extern cvar_t *sv_gravity;
@@ -1350,6 +1351,7 @@ void player_die (edict_t * self, edict_t * inflictor, edict_t * attacker,
 //
 void ServerCommand (void);
 qboolean SV_FilterPacket (char *from, int *temp);
+qboolean SV_FilterSBPacket(char* from, int* temp); //rekkie -- silence ban
 void Kick_Client (edict_t * ent);
 qboolean Ban_TeamKiller (edict_t * ent, int rounds);
 
@@ -1492,6 +1494,8 @@ typedef struct
 
 	qboolean connected;		// a loadgame will leave valid entities that
 	// just don't have a connection yet
+
+	qboolean silence_banned; //rekkie -- silence ban
 
 	int admin;
 

--- a/source/g_main.c
+++ b/source/g_main.c
@@ -350,6 +350,7 @@ cvar_t *g_select_empty;
 cvar_t *dedicated;
 cvar_t *steamid;
 cvar_t *filterban;
+cvar_t *silenceban; //rekkie -- silence ban
 cvar_t *sv_maxvelocity;
 cvar_t *sv_gravity;
 cvar_t *sv_rollspeed;

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -370,6 +370,7 @@ void InitGame( void )
 	capturelimit = gi.cvar( "capturelimit", "0", CVAR_SERVERINFO );
 	password = gi.cvar( "password", "", CVAR_USERINFO );
 	filterban = gi.cvar( "filterban", "1", 0 );
+	silenceban = gi.cvar( "silenceban", "1", 0); //rekkie -- silence ban
 	needpass = gi.cvar( "needpass", "0", CVAR_SERVERINFO );
 	radiolog = gi.cvar( "radiolog", "0", 0 );
 	teamplay = gi.cvar( "teamplay", "0", CVAR_SERVERINFO | CVAR_LATCH );

--- a/source/g_spawn.c
+++ b/source/g_spawn.c
@@ -252,6 +252,7 @@ void SP_misc_easterchick2 (edict_t * self);
 //zucc - item replacement function
 void CheckItem (edict_t * ent);
 int LoadFlagsFromFile (const char *mapname);
+void SVCmd_CheckSB_f(void); //rekkie -- silence ban
 extern void UnBan_TeamKillers(void);
 
 //AQ2:TNG - Slicer New location code
@@ -1199,6 +1200,8 @@ void SpawnEntities (char *mapname, char *entities, char *spawnpoint)
 	}
 
 	G_LoadLocations();
+
+	SVCmd_CheckSB_f(); //rekkie -- silence ban
 
 	UnBan_TeamKillers();
 

--- a/source/g_svcmds.c
+++ b/source/g_svcmds.c
@@ -339,6 +339,384 @@ void SVCmd_WriteIP_f (void)
 	fclose (f);
 }
 
+//rekkie -- silence ban -- s
+/*================================================================================================================================================================
+
+SILENCE BAN FILTERING - Indefinitely or temporarly silence a player; they can see their own messages, but other players will not see them.
+
+The ip address is specified in dot format, and any unspecified digits will match any value, so you can specify an entire class C network with "addip 192.246.40"
+
+
+sv addsb <ip> <OPTIONAL: number of games>
+-----------------------------------------
+Add address, including subnet, to the silence ban list. Adding 192.168 to the list would block out everyone in the 192.168.*.* net block.
+OPTIONAL:	If number of games is specified, the address will be silenced for the specified number of games.
+			If not specified the address will be silenced indefinitely.
+
+
+sv removesb <ip>
+----------------
+Remove address from the silence ban list. Removing <IP> address must be done in the way it was added, you cannot addip a subnet then removesb a single host ip.
+
+
+sv listsb
+---------
+Prints the current list of filters.
+
+
+sv writesb
+----------
+Writes bans to listsb.cfg, which can then be run by adding +exec listsb.cfg to the server's command line.
+WARNING:	Bans are not saved or loaded by default. Admins must run sv writesb to update listsb.cfg with the changes.
+
+
+silenceban <0 or 1> Default: 1
+------------------------------
+silenceban 1		This acts as a BLACKLIST, meaning IPs listed on (sv listsb) will be DENIED from talking to other players in game.
+silenceban 0		This acts as a WHITELIST, meaning IPs listed on (sv listsb) will be ALLOWED to talk to other players in game.
+
+==================================================================================================================================================================*/
+
+#define MAX_SB_FILTERS   1024
+typedef struct
+{
+	unsigned mask;
+	unsigned compare;
+	int temp_sban_games;
+}
+sb_filter_t;
+sb_filter_t sb_filters[MAX_SB_FILTERS];
+int num_sb_filters;
+
+//===========================
+//== StringToSilenceFilter ==
+//===========================
+static qboolean StringToSilenceFilter(char* s, sb_filter_t* f, int temp_sban_games)
+{
+	char num[128];
+	int i, j;
+	byte b[4] = { 0,0,0,0 };
+	byte m[4] = { 0,0,0,0 };
+
+	for (i = 0; i < 4; i++)
+	{
+		if (*s < '0' || *s > '9')
+		{
+			gi.cprintf(NULL, PRINT_HIGH, "Bad silence filter address: %s\n", s);
+			return false;
+		}
+
+		j = 0;
+
+		while (*s >= '0' && *s <= '9')
+			num[j++] = *s++;
+
+		num[j] = 0;
+		b[i] = atoi(num);
+
+		if (b[i] != 0)
+			m[i] = 255;
+
+		if (!*s)
+			break;
+		s++;
+	}
+
+	f->mask = *(unsigned*)m;
+	f->compare = *(unsigned*)b;
+	f->temp_sban_games = temp_sban_games;
+
+	return true;
+}
+
+//=======================
+//== SV_FilterSBPacket ==
+//=======================
+qboolean SV_FilterSBPacket(char* from, int* temp) // temp is optional
+{
+	int i = 0;
+	unsigned in;
+	byte m[4] = { 0,0,0,0 };
+	char* p;
+
+	p = from;
+	while (*p && i < 4)
+	{
+		while (*p >= '0' && *p <= '9')
+		{
+			m[i] = m[i] * 10 + (*p - '0');
+			p++;
+		}
+		if (!*p || *p == ':')
+			break;
+		i++, p++;
+	}
+
+	in = *(unsigned*)m;
+
+	for (i = 0; i < num_sb_filters; i++)
+	{
+		if ((in & sb_filters[i].mask) == sb_filters[i].compare)
+		{
+			if (temp != NULL)
+				*temp = sb_filters[i].temp_sban_games;
+			return (int)silenceban->value;
+		}
+	}
+
+	return (int)!silenceban->value;
+}
+
+//================
+//== SB_Have_IP ==
+//================
+qboolean SB_Have_IP(char* from) // Check if IP is in the silence ban list
+{
+	int i = 0;
+	unsigned in;
+	byte m[4] = { 0,0,0,0 };
+	char* p;
+
+	p = from;
+	while (*p && i < 4)
+	{
+		while (*p >= '0' && *p <= '9')
+		{
+			m[i] = m[i] * 10 + (*p - '0');
+			p++;
+		}
+		if (!*p || *p == ':')
+			break;
+		i++, p++;
+	}
+
+	in = *(unsigned*)m;
+
+	for (i = 0; i < num_sb_filters; i++)
+	{
+		if ((in & sb_filters[i].mask) == sb_filters[i].compare)
+		{
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+//===================
+//== SVCmd_AddSB_f ==
+//===================
+void SVCmd_AddSB_f(void)
+{
+	int i;
+
+	if (gi.argc() < 3)
+	{
+		gi.cprintf(NULL, PRINT_HIGH, "Usage:  sv addsb <ip-mask> <OPTIONAL: num games>\n");
+		return;
+	}
+
+	if (SB_Have_IP(gi.argv(2))) // Check if IP was already added
+	{
+		gi.cprintf(NULL, PRINT_HIGH, "This IP %s is already on the list\n", gi.argv(2));
+		return;
+	}
+
+	for (i = 0; i < num_sb_filters; i++)
+	{
+		if (sb_filters[i].compare == 0xffffffff)
+			break;			// free spot
+	}
+
+	if (i == num_sb_filters)
+	{
+		if (num_sb_filters == MAX_SB_FILTERS)
+		{
+			gi.cprintf(NULL, PRINT_HIGH, "Silence filter list is full\n");
+			return;
+		}
+		num_sb_filters++;
+	}
+
+	if (gi.argc() == 4) // Admin specified number of games for a temporary ban
+	{
+		if (!StringToSilenceFilter(gi.argv(2), &sb_filters[i], atoi(gi.argv(3))))
+			sb_filters[i].compare = 0xffffffff;
+
+		gi.cprintf(NULL, PRINT_HIGH, "Added silence to IP/MASK: %s for %s games\n", gi.argv(2), gi.argv(3));
+	}
+	else // Admin did not specify number of games, therefore the ban is indefinite
+	{
+		if (!StringToSilenceFilter(gi.argv(2), &sb_filters[i], 0))
+			sb_filters[i].compare = 0xffffffff;
+
+		gi.cprintf(NULL, PRINT_HIGH, "Added silence to IP/MASK: %s\n", gi.argv(2));
+	}
+
+	// Check which client(s) need a silence applied
+	for (i = 0; i < game.maxclients; i++)
+	{
+		if (game.clients[i].pers.connected == false)
+			continue;
+		if (game.clients[i].pers.silence_banned)
+			continue;
+		if (SV_FilterSBPacket(game.clients[i].pers.ip, NULL))
+		{
+			game.clients[i].pers.silence_banned = true;
+			gi.cprintf(NULL, PRINT_HIGH, "Adding silence to player: %s\n", game.clients[i].pers.netname);
+		}
+	}
+}
+
+//====================
+// SVCmd_RemoveSB_f ==
+//====================
+void SVCmd_RemoveSB_f(void)
+{
+	sb_filter_t f;
+	int i, j;
+
+	if (gi.argc() < 3)
+	{
+		gi.cprintf(NULL, PRINT_HIGH, "Usage:  sv removesb <ip-mask>\n");
+		return;
+	}
+
+	if (!StringToSilenceFilter(gi.argv(2), &f, 0))
+		return;
+
+	for (i = 0; i < num_sb_filters; i++)
+	{
+		if (sb_filters[i].mask == f.mask && sb_filters[i].compare == f.compare)
+		{
+			for (j = i + 1; j < num_sb_filters; j++)
+				sb_filters[j - 1] = sb_filters[j];
+
+			num_sb_filters--;
+			gi.cprintf(NULL, PRINT_HIGH, "Removed silence from IP/MASK: %s\n", gi.argv(2));
+
+			// Check which client(s) need to their silenced removed
+			for (i = 0; i < game.maxclients; i++)
+			{
+				if (game.clients[i].pers.connected == false)
+					continue;
+				if (game.clients[i].pers.silence_banned == false)
+					continue;
+				if (SV_FilterSBPacket(game.clients[i].pers.ip, NULL) == false)
+				{
+					game.clients[i].pers.silence_banned = false;
+					gi.cprintf(NULL, PRINT_HIGH, "Removing silence from player: %s\n", game.clients[i].pers.netname);
+				}
+			}
+
+			return;
+		}
+	}
+	gi.cprintf(NULL, PRINT_HIGH, "Cannot find IP/MASK: %s\n", gi.argv(2));
+}
+
+//===================
+// SVCmd_CheckSB_f ==
+//===================
+void SVCmd_CheckSB_f(void) // Check for temporary silences that need removing
+{
+	// We don't directly unban them all - we subtract 1 from temp_ban_games, and unban them if it's 0.
+	int i, j;
+	for (i = 0; i < num_sb_filters; i++)
+	{
+		if (sb_filters[i].temp_sban_games > 0)
+		{
+			if (!--sb_filters[i].temp_sban_games)
+			{
+				// Re-pack the filters
+				for (j = i + 1; j < num_sb_filters; j++)
+					sb_filters[j - 1] = sb_filters[j];
+				num_sb_filters--;
+				gi.cprintf(NULL, PRINT_HIGH, "Removed silence\n");
+
+				// Since we removed the current we have to re-process the new current
+				i--;
+			}
+		}
+	}
+
+	// Check which client(s) need to their silenced removed
+	int temp_sban_games = 0;
+	for (i = 0; i < game.maxclients; i++)
+	{
+		if (game.clients[i].pers.connected == false)
+			continue;
+		if (game.clients[i].pers.silence_banned == false)
+			continue;
+		if (SV_FilterSBPacket(game.clients[i].pers.ip, &temp_sban_games) == false && temp_sban_games == 0)
+		{
+			game.clients[i].pers.silence_banned = false;
+			gi.cprintf(NULL, PRINT_HIGH, "Removing silence from player: %s\n", game.clients[i].pers.netname);
+		}
+	}
+}
+
+//====================
+//== SVCmd_ListSB_f ==
+//====================
+void SVCmd_ListSB_f(void)
+{
+	int i;
+	byte b[4];
+
+	gi.cprintf(NULL, PRINT_HIGH, "Silence filter list:\n");
+	for (i = 0; i < num_sb_filters; i++)
+	{
+		*(unsigned*)b = sb_filters[i].compare;
+		if (!sb_filters[i].temp_sban_games)
+			gi.cprintf(NULL, PRINT_HIGH, "%3i.%3i.%3i.%3i\n", b[0], b[1], b[2], b[3]);
+		else
+			gi.cprintf(NULL, PRINT_HIGH, "%3i.%3i.%3i.%3i (%d more game(s))\n", b[0], b[1], b[2], b[3], sb_filters[i].temp_sban_games);
+	}
+}
+
+//=====================
+//== SVCmd_WriteSB_f ==
+//=====================
+void SVCmd_WriteSB_f(void)
+{
+	FILE* f;
+	char name[MAX_OSPATH];
+	byte b[4];
+	int i;
+	cvar_t* game;
+
+	game = gi.cvar("game", "", 0);
+
+	if (!*game->string)
+		sprintf(name, "%s/listsb.cfg", GAMEVERSION);
+	else
+		sprintf(name, "%s/listsb.cfg", game->string);
+
+	gi.cprintf(NULL, PRINT_HIGH, "Writing %s\n", name);
+
+	f = fopen(name, "wb");
+	if (!f)
+	{
+		gi.cprintf(NULL, PRINT_HIGH, "Couldn't open %s\n", name);
+		return;
+	}
+
+	fprintf(f, "set silenceban %d\n", (int)silenceban->value);
+
+	for (i = 0; i < num_sb_filters; i++)
+	{
+		if (!sb_filters[i].temp_sban_games)
+		{
+			*(unsigned*)b = sb_filters[i].compare;
+			fprintf(f, "sv addsb %i.%i.%i.%i\n", b[0], b[1], b[2], b[3]);
+		}
+	}
+
+	fclose(f);
+}
+//rekkie -- silence ban -- e
+
 /*
 =================
 SV_Nextmap_f
@@ -660,6 +1038,16 @@ void ServerCommand (void)
 		SVCmd_ListIP_f ();
 	else if (Q_stricmp (cmd, "writeip") == 0)
 		SVCmd_WriteIP_f ();
+	//rekkie -- silence ban -- s
+	else if (Q_stricmp(cmd, "addsb") == 0)
+		SVCmd_AddSB_f();
+	else if (Q_stricmp(cmd, "removesb") == 0)
+		SVCmd_RemoveSB_f();
+	else if (Q_stricmp(cmd, "listsb") == 0)
+		SVCmd_ListSB_f();
+	else if (Q_stricmp(cmd, "writesb") == 0)
+		SVCmd_WriteSB_f();
+	//rekkie -- silence ban -- e
 	else if (Q_stricmp (cmd, "nextmap") == 0)
 		SVCmd_Nextmap_f (gi.argv (2));	// Added by Black Cross
 	else if (Q_stricmp (cmd, "reloadmotd") == 0)

--- a/source/game.vcxproj
+++ b/source/game.vcxproj
@@ -128,7 +128,8 @@
     <Link>
       <LinkDLL>true</LinkDLL>
       <SubSystem>Windows</SubSystem>
-      <BaseAddress>0x20000000</BaseAddress>
+      <BaseAddress>
+      </BaseAddress>
       <AdditionalDependencies>winmm.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>.\game.def</ModuleDefinitionFile>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -2915,6 +2915,17 @@ qboolean ClientConnect(edict_t * ent, char *userinfo)
 		IRC_printf(IRC_T_SERVER, "%n@%s connected", value, ipaddr_buf);
 	}
 
+	//rekkie -- silence ban -- s
+	if (SV_FilterSBPacket(ipaddr_buf, NULL)) // Check if player has been silenced
+	{
+		ent->client->pers.silence_banned = true;
+		value = Info_ValueForKey(userinfo, "name");
+		gi.dprintf("%s has been [SILENCED] because they're on the naughty list\n", value); // Notify console the player is silenced
+	}
+	else
+		ent->client->pers.silence_banned = false;
+	//rekkie -- silence ban -- e
+
 	//set connected on ClientBeginDeathmatch as clientconnect doesn't always
 	//guarantee a client is actually making it all the way into the game.
 	//ent->client->pers.connected = true;


### PR DESCRIPTION
Added safeguards when compiling RPC for Windows. Requires Microsoft Visual Compiler 2019 or greater. These checks are in place so the MinGW compiler can ignore RPC code.